### PR TITLE
Allow for integration testing of chasten's ability to read from remote configuration files

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,4 @@
 chasten:
   # point to a checks file
   checks-file:
-    - https://raw.githubusercontent.com/simojo/chasten-configuration/master/checks.yml
+    - checks.yml

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,4 @@
 chasten:
   # point to a checks file
   checks-file:
-    - checks.yml
+    - https://raw.githubusercontent.com/simojo/chasten-configuration/master/checks.yml

--- a/config_url_and_local_checks_files.yml
+++ b/config_url_and_local_checks_files.yml
@@ -1,0 +1,9 @@
+# chasten configuration
+# used for testing purposes
+chasten:
+  # point to a combination of checks files and local files
+  checks-file:
+    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml
+    - checks.yml
+    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml
+    - checks.yml

--- a/config_url_and_local_checks_files.yml
+++ b/config_url_and_local_checks_files.yml
@@ -3,7 +3,7 @@
 chasten:
   # point to a combination of checks files and local files
   checks-file:
-    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml
+    - https://raw.githubusercontent.com/AstuteSource/chasten-configuration/master/dummy_checks.yml
     - checks.yml
-    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml
+    - https://raw.githubusercontent.com/AstuteSource/chasten-configuration/master/dummy_checks.yml
     - checks.yml

--- a/config_url_checks_file.yml
+++ b/config_url_checks_file.yml
@@ -5,4 +5,4 @@
 chasten:
   # point to a checks file
   checks-file:
-    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml
+    - https://raw.githubusercontent.com/AstuteSource/chasten-configuration/master/dummy_checks.yml

--- a/config_url_checks_file.yml
+++ b/config_url_checks_file.yml
@@ -1,0 +1,8 @@
+# chasten configuration
+# used for testing purposes
+# meant to be called as a url endpoint
+# Example: https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/url_config.yml
+chasten:
+  # point to a checks file
+  checks-file:
+    - https://raw.githubusercontent.com/AstuteSource/chasten/master/.chasten/checks.yml

--- a/dummy_checks.yml
+++ b/dummy_checks.yml
@@ -1,0 +1,36 @@
+checks:
+  - name: "class-definition"
+    code: "CDF"
+    id: "C001"
+    pattern: './/ClassDef'
+    count:
+      min: 1
+      max: null
+  - name: "all-function-definition"
+    code: "AFD"
+    id: "F001"
+    pattern: './/FunctionDef'
+    count:
+      min: 1
+      max: null
+  - name: "dummy-test-non-test-function-definition"
+    code: "NTF"
+    id: "F002"
+    pattern: './/FunctionDef[not(contains(@name, "test_"))]'
+    count:
+      min: null
+      max: null
+  - name: "dummy-test-single-nested-if"
+    code: "SNI"
+    id: "CL001"
+    pattern: './/FunctionDef/body//If'
+    count:
+      min: null
+      max: null
+  - name: "dummy-test-double-nested-if"
+    code: "DNI"
+    id: "CL002"
+    pattern: './/FunctionDef/body//If[ancestor::If and not(parent::orelse)]'
+    count:
+      min: null
+      max: null


### PR DESCRIPTION
This PR creates three new files that will be referenced from `chasten`'s test suite while testing the pulling of remote configuration files.

* `config_url_and_local_checks_files.yml` references checks files as if they were on the local filesystem and represented as URLs. 
  * When calling this config as a URL, it should break, because you cannot have a remote file referencing your local files.
  * When calling this config locally, it should run normally, because local configs are allowed to reference remote and/or local checks files.
* `config_url_checks_file.yml` references a URL as the checks file.
  * When called as a URL, this should work as expected, because URL config files may reference other URL checks files.
  * When called as a local path, this should work as expected, because local config files are allowed to reference URL checks files.
* `dummy_checks.yml` is a copy of the checks in the main `chasten` repo. These checks do not enforce any meaningful checks, and are only to see if chasten will read the checks file correctly.